### PR TITLE
Fixed opening hours popup on Branch page

### DIFF
--- a/rentaroo/src/components/BranchCard.jsx
+++ b/rentaroo/src/components/BranchCard.jsx
@@ -9,7 +9,8 @@ const BranchCard = ({branches, latitude, longitude}) => {
 
 const [isPopupOpen, setIsPopupOpen] = useState(false);
 
-const handleOpenPopup = () => {
+const handleOpenPopup = (e) => {
+    e.preventDefault();
     setIsPopupOpen(true);
   };
 


### PR DESCRIPTION
We are no longer sent back to the top of the page after opening the branches hours popup